### PR TITLE
ignore Set-Cookie and Vary headers to allow caching

### DIFF
--- a/conf/nginx.conf.server
+++ b/conf/nginx.conf.server
@@ -10,6 +10,9 @@ proxy_cache_lock on;
 ## The time here is overridden by our injected `expires $uri_expiry` header.
 proxy_cache_valid 200 206 301 302 1s;
 
+## Ignore headers that make requests uncacheable
+proxy_ignore_headers Set-Cookie Vary;
+
 ## Settings for handling range requests
 slice 1m;
 proxy_set_header  Range $slice_range;


### PR DESCRIPTION
Some RSS endpoints are returning a `Set-Cookie` header, which Nginx usually interprets as an uncacheable response. This ignores that header to allow caching.

The `Vary` header can also be used to indicate no-caching, and we should ignore that too.