### PR TITLE
handle errors from upstream proxy

### DIFF
--- a/conf/nginx.conf.server
+++ b/conf/nginx.conf.server
@@ -144,7 +144,7 @@ server {
         ## This config attempts to serve updated responses immediately,
         ## serving a stale response if there is an error/timeout.
         ## Use when immediate updates are preferred.
-        proxy_cache_use_stale error timeout;
+        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
         proxy_cache_background_update off;
 
         # These timeouts ensure that the stale cache is used quickly if network


### PR DESCRIPTION
under some offline network conditions, Nginx sends 500s to the proxy instead of outright throwing an error. appears to happen if Nginx thinks it's online and attempts to hit the DNS server and fails to get a response (`sendfile() failed (22: Invalid argument) while resolving, resolver 8.8.8.8:53`). 

this ensures that a stale response is returned in those cases.