### PR TITLE
allow disabling transparent proxy

### DIFF
--- a/conf/nginx.conf.server
+++ b/conf/nginx.conf.server
@@ -75,6 +75,7 @@ map $http_range $proxy_cache_backend {
 
 server {
     include ./transparent_proxy/*.conf;
+    listen 444 ssl;
     listen 3128;
 
     ssl_certificate     ./nginx.crt;
@@ -93,7 +94,7 @@ server {
     proxy_connect_connect_timeout       10s;
     proxy_connect_read_timeout          10s;
     proxy_connect_send_timeout          10s;
-    proxy_connect_address               127.0.0.1:443;
+    proxy_connect_address               127.0.0.1:444;
 
     location / {
         resolver 8.8.8.8;

--- a/conf/nginx.conf.server
+++ b/conf/nginx.conf.server
@@ -74,9 +74,8 @@ map $http_range $proxy_cache_backend {
 }
 
 server {
-    listen 80;
+    include ./transparent_proxy/*.conf;
     listen 3128;
-    listen 443 ssl;
 
     ssl_certificate     ./nginx.crt;
     ssl_certificate_key ./nginx.key;

--- a/conf/transparent_proxy/transparent.conf
+++ b/conf/transparent_proxy/transparent.conf
@@ -1,0 +1,2 @@
+listen 80;
+listen 443 ssl;

--- a/config.sh
+++ b/config.sh
@@ -6,6 +6,14 @@ mkdir -p ./build/certs
 cp ./conf/nginx.conf ./build/conf
 cp ./conf/nginx.conf.server ./build/conf
 
+# Enable transparent mode if not explicitly disabled
+mkdir -p ./build/conf/transparent_proxy
+if [ -z "${DISABLE_TRANSPARENT_PROXY}" ]; then
+    cp ./conf/transparent_proxy/*.conf ./build/conf/transparent_proxy
+else
+    rm -rf ./build/conf/transparent_proxy/*
+fi
+
 cp ./certs/nginx.crt ./build/conf
 cp ./certs/nginx.key ./build/conf
 cp ./certs/cacert.pem ./build/conf


### PR DESCRIPTION
If `make install` is run with `DISABLE_TRANSPARENT_PROXY=1`, will not start nginx on ports 80 and 443.