### PR TITLE
use $http_host to include ports, $request_uri to avoid injection

### DIFF
--- a/conf/nginx.conf.server.template
+++ b/conf/nginx.conf.server.template
@@ -100,7 +100,7 @@ server {
     location / {
         resolver 8.8.8.8;
 
-        proxy_set_header Host            $host;
+        proxy_set_header Host            $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
 
         proxy_pass $proxy_cache_backend;
@@ -129,12 +129,12 @@ server {
     add_header Funes-Cache-Status $upstream_cache_status;
 
     location / {
-        proxy_set_header Host            $host;
+        proxy_set_header Host            $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
 
         proxy_pass $proxy_rewrite_backend;
         proxy_cache fwd_proxy_cache;
-        proxy_cache_key $proxy_method$request_method$host$uri$is_args$args;
+        proxy_cache_key $proxy_method$request_method$http_host$request_uri;
 
         ## This config serves stale responses when updating the cache.
         ## Use when immediate updates are not necessary.
@@ -192,7 +192,7 @@ server {
     location / {
         resolver 8.8.8.8;
 
-        proxy_pass $forward_proxy_scheme://$host$uri$is_args$args;
+        proxy_pass $forward_proxy_scheme://$http_host$request_uri;
 
         proxy_ssl_verify on;
         proxy_ssl_verify_depth 2;
@@ -234,10 +234,10 @@ server {
 
         add_header Funes-Cache-Status $upstream_cache_status;
 
-        proxy_pass $forward_range_proxy_scheme://$host$uri$is_args$args;
+        proxy_pass $forward_range_proxy_scheme://$http_host$request_uri;
         proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie Vary;
         proxy_cache fwd_proxy_cache;
-        proxy_cache_key $forward_range_proxy_scheme$request_method$host$uri$is_args$args$slice_range;
+        proxy_cache_key $forward_range_proxy_scheme$request_method$http_host$request_uri$slice_range;
         proxy_cache_use_stale error timeout;
         proxy_cache_background_update off;
         proxy_cache_valid 200 206 3650d;

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-requests
-sultan
+requests==2.21.0
+sultan==0.8.1


### PR DESCRIPTION
Fixes issue where Funes overrides `<host>:<port>` requests to `<host>:80`. Also fixes header injection vulnerability with `$uri` variable.

**NEEDS TESTING**

https://serverfault.com/questions/861749/nginx-request-port
https://stackoverflow.com/questions/48708361/nginx-request-uri-vs-uri

