### PR TITLE
silence logs generated by os.execute

### DIFF
--- a/conf/generate_ssl_certs.template.lua
+++ b/conf/generate_ssl_certs.template.lua
@@ -92,7 +92,7 @@ end
 function generate_csr(common_name)
     local private_key, csr, signed_cert = cert_disk_locations(common_name)
     local country, state, city, company = cert_info()
-    local openssl_command = string.format("/bin/bash -c 'RANDFILE=/data/funes/.rnd openssl req -new -newkey rsa:2048 -keyout %s -nodes -out %s -subj \"/C=%s/ST=%s/L=%s/O=%s/CN=%s\"'", private_key, csr, country, state, city, company, common_name)
+    local openssl_command = string.format("/bin/bash -c 'RANDFILE=/data/funes/.rnd openssl req -new -newkey rsa:2048 -keyout %s -nodes -out %s -subj \"/C=%s/ST=%s/L=%s/O=%s/CN=%s\" >/dev/null 2>&1'", private_key, csr, country, state, city, company, common_name)
     ngx.log(ngx.DEBUG, openssl_command)
     local ret = os.execute(openssl_command)
     return ret
@@ -101,7 +101,7 @@ end
 -- Sign a CSR using the root CA cert and key.
 function sign_csr(common_name, root_ca_cert, root_ca_key)
     local private_key, csr, signed_cert = cert_disk_locations(common_name)
-    local openssl_command = string.format("faketime yesterday /bin/bash -c 'RANDFILE=/data/funes/.rnd openssl x509 -req -extfile <(printf \"subjectAltName=DNS:%s\") -days 365 -in %s -CA %s -CAkey %s -CAcreateserial -out %s'", common_name, csr, root_ca_cert, root_ca_key, signed_cert)
+    local openssl_command = string.format("faketime yesterday /bin/bash -c 'RANDFILE=/data/funes/.rnd openssl x509 -req -extfile <(printf \"subjectAltName=DNS:%s\") -days 365 -in %s -CA %s -CAkey %s -CAcreateserial -out %s >/dev/null 2>&1'", common_name, csr, root_ca_cert, root_ca_key, signed_cert)
     ngx.log(ngx.DEBUG, openssl_command)
     local ret = os.execute(openssl_command)
     return ret


### PR DESCRIPTION
Lua's `os.execute` automatically ships logs to the *default* log directory, instead of obeying nginx configuration. This can cause problems with logs being unexpectedly written. Other option would be to use `io.popen` to stream the output into Lua, but that has an issue where you cannot get the command's exit status. Because we only care about the exit status we will use `os.execute` and silence stdout/stderr from the openssl commands.