### PR TITLE
Allow underscores in headers

### DIFF
--- a/conf/nginx.conf.server.template
+++ b/conf/nginx.conf.server.template
@@ -11,6 +11,9 @@ proxy_cache_lock on;
 proxy_ignore_headers Set-Cookie Vary X-Accel-Buffering;
 proxy_buffering on;
 
+## Allow underscores in headers. Without this directive, nginx will strip headers with underscores.
+underscores_in_headers on;
+
 resolver ${NAMESERVER} ipv6=off valid=10s;
 
 # ====================== Expiration Rules ====================== #


### PR DESCRIPTION
While uncommon, underscores in headers are valid and some APIs use them to send API keys. By default nginx will strip headers with underscores unless the `underscores_in_headers` directive is turned on.