### PR TITLE
Set http version 1.1 for all upstream connections

### DIFF
--- a/conf/nginx.conf.server.template
+++ b/conf/nginx.conf.server.template
@@ -11,6 +11,10 @@ proxy_cache_lock on;
 proxy_ignore_headers Set-Cookie Vary;
 proxy_buffering on;
 
+# Some websites reject http 1.0 requests, which is used by default by nginx. This setting forces http 1.1.
+# This is also necessary for keep-alive connections such as SSE.
+proxy_http_version 1.1;
+
 ## Allow underscores in headers. Without this directive, nginx will strip headers with underscores.
 underscores_in_headers on;
 
@@ -94,7 +98,6 @@ server {
         # if too low causes "504 Gateway Timeout"
         proxy_read_timeout ${PROXY_READ_DATA_TIMEOUT};
 
-        proxy_http_version 1.1;
         proxy_cache_bypass $cache_bypass;
     }
 }


### PR DESCRIPTION
We were previously only setting http version 1.1 for first upstream server connection but we need to set it for all servers as some websites not block 1.0 connections. This ensures the final upstream server when connecting to the external server uses http 1.1